### PR TITLE
Add task metadata, notes, batch mode, and TUI integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,10 @@ modernc.org/sqlite v1.46.1
 - **Priority Levels**: Low, Medium, High, Urgent with color coding
 - **Tags**: Comma-separated tag support
 - **Recurring Tasks**: Daily, weekly, monthly, or yearly recurrence; auto-spawns next occurrence on completion
-- **Task Dependencies**: Block tasks by other task IDs
+- **Task Dependencies**: Block tasks by other task IDs; CLI via `--blocks` flag on `add`/`edit`, `--clear-blocks` on `edit`
+- **Delete Guard**: Refuses to delete tasks that block others (exit code 1); `--cascade` to confirm
+- **Self-Block Guard**: Store-level rejection of self-referential dependencies
+- **Metadata**: Structured key-value pairs (`--meta key=value`) stored as JSON; filterable with AND logic via `rondo list --meta key=value`
 - **Time Logging**: Log time spent on tasks with optional notes
 
 ### Journal
@@ -77,7 +80,7 @@ modernc.org/sqlite v1.46.1
 Full Cobra-based CLI with all features available as subcommands:
 - **Global flags**: `--format table|json`, `--json`, `--quiet`, `--no-color`
 - **TTY-aware output**: Styled tables with Unicode borders + ANSI colors when TTY; plain tabwriter when piped
-- **Commands**: `add`, `done`, `list`, `show`, `edit`, `delete`, `status`, `subtask`, `timelog`, `recur`, `journal`, `focus`, `export`, `stats`, `config`, `completion`
+- **Commands**: `add`, `done`, `list`, `show`, `edit`, `delete`, `status`, `subtask`, `timelog`, `note`, `recur`, `journal`, `focus`, `export`, `stats`, `config`, `batch`, `completion`
 - **Shell completions**: bash, zsh, fish, powershell via `rondo completion`
 
 ### UI Layout
@@ -124,6 +127,8 @@ internal/
     errors.go                   # NotFoundError type with errors.As support
     confirm.go                  # Confirmation prompts (styled when TTY)
     tasks.go                    # add, done, list, show, edit, delete, status
+    batch.go                    # batch (stdin newline-delimited JSON commands)
+    note.go                     # note (add, list, edit, delete)
     journal.go                  # journal (add, list, show, edit, delete, hide)
     export.go                   # export (md, json, file output with buffered flush)
     subtasks.go                 # subtask (add, list, done, edit, delete)
@@ -163,10 +168,17 @@ type Task struct {
     ID, Title, Description, Status, Priority
     DueDate, CreatedAt, UpdatedAt
     RecurFreq, RecurInterval        // Recurrence (daily, weekly, monthly, yearly)
-    BlockedByIDs []int64            // Task dependency IDs
+    BlockedByIDs []int64            // Tasks that block this one
+    BlocksIDs    []int64            // Tasks this one blocks
     Subtasks     []Subtask
     Tags         []string
+    Metadata     map[string]string  // Structured key-value pairs (JSON column)
     TimeLogs     []TimeLog
+    Notes        []TaskNote         // Timestamped comments (task_notes table)
+}
+
+type TaskNote struct {
+    ID, TaskID, Body, CreatedAt
 }
 
 type Subtask struct {
@@ -216,10 +228,15 @@ The app uses a mode enum to track UI state:
 - **Printer pattern**: `cli/output.go` — `Printer` struct with `noColor`/`quiet` flags; methods: `Table()`, `Success()`, `Bold()`, `Dim()`, `Colored()`, `JSON()`
 - **TTY detection**: `isTTY()` via `go-isatty` (not `ModeCharDevice`); auto-disables color when piped unless `--no-color` explicitly set
 - **Styled tables**: lipgloss/table with `RoundedBorder()` when TTY, tabwriter fallback when piped; `writerWidth()` constrains to terminal width
+- **Batch mode**: `rondo batch` reads newline-delimited JSON from stdin; creates a fresh cobra command tree per invocation to prevent flag state leaking
+- **UTC timestamps**: All `time.Now()` calls use `.UTC()`; all date parsing uses `time.UTC` (not `time.Local`)
+- **Metadata storage**: JSON `TEXT` column with `marshalMetadata()`/`parseMetadata()` helpers; `addColumnIfNotExists()` migration
+- **Blocker enrichment**: JSON output for `blocked_by`/`blocks` contains `{id, title, status}` objects (not bare IDs); resolved via `taskIndex` lookup
+- **Delete guard**: CLI checks `ListBlocksIDs()` before delete; exit code 1 + error listing blocked tasks unless `--cascade` is passed
 
 ### SQLite Schema
 Database at `~/.todo-app/todo.db` with tables:
-- `tasks`, `subtasks`, `tags`, `task_blocks` — task management (ON DELETE CASCADE)
+- `tasks`, `subtasks`, `tags`, `task_blocks`, `task_notes` — task management (ON DELETE CASCADE)
 - `time_logs` — time tracking per task
 - `journal_notes`, `journal_entries` — journal (ON DELETE CASCADE, indexed)
 - `focus_sessions` — Pomodoro session tracking

--- a/README.md
+++ b/README.md
@@ -97,9 +97,13 @@ All data is stored locally at `~/.todo-app/` — no setup needed.
 - **Priority levels** — Low, Medium, High, Urgent (color-coded)
 - **Due dates** — with overdue detection and sort support
 - **Tags** — comma-separated, filterable
+- **Metadata** — structured key-value pairs (`--meta key=value`), filterable with AND logic
 - **Recurring tasks** — daily, weekly, monthly, or yearly; auto-spawns next on completion
-- **Task dependencies** — mark tasks as blocked by others
+- **Task dependencies** — block tasks via `--blocks` flag; enriched JSON refs with title and status
+- **Delete guard** — refuses to delete tasks that block others; `--cascade` to override
+- **Task notes** — timestamped comments on tasks for status updates, blockers, justifications
 - **Time logging** — log time spent with optional notes
+- **Batch mode** — pipe newline-delimited JSON commands to `rondo batch`
 - **Sorting** — by creation date, due date, or priority
 - **Fuzzy search** — instant filter across tasks
 
@@ -163,18 +167,31 @@ rondo stats
 ```bash
 # Tasks
 rondo add "Buy groceries" --priority high --due 2026-03-15 --tags "home,shopping"
+rondo add "Task with context" --meta source=email --meta assigned=john
+rondo add "Blocked task" --blocks 1,2          # this task blocks tasks 1 and 2
 rondo list --status pending --sort priority --limit 10
 rondo list --priority urgent --overdue --format json
+rondo list --meta source=email --json          # filter by metadata (AND logic)
 rondo show 3
 rondo edit 3 --title "Buy organic groceries" --due 2026-03-20
+rondo edit 3 --meta assigned=jane              # merge metadata (adds/overwrites keys)
+rondo edit 3 --blocks 4,5                      # set tasks this one blocks (replaces)
+rondo edit 3 --clear-blocks                    # remove all blockers
 rondo done 3 4 5
-rondo delete 3 --force
+rondo delete 3 --force                         # fails if task blocks others (exit 1)
+rondo delete 3 --force --cascade               # delete + unblock dependents
 rondo status 3 active
 
 # Subtasks
 rondo subtask add 3 "Pick up milk"
 rondo subtask list 3
 rondo subtask done 3 1
+
+# Notes (timestamped comments)
+rondo note add 3 "Blocked on vendor API key"
+rondo note list 3                              # table or --json
+rondo note edit 3 1 "Updated: key received"
+rondo note delete 3 1 --force
 
 # Time tracking
 rondo timelog add 3 1h30m --note "Deep work session"
@@ -195,6 +212,10 @@ rondo journal show today
 rondo focus start --task-id 3 --duration 25m
 rondo focus status
 rondo focus stats --days 14
+
+# Batch (multiple commands in one call)
+echo '{"cmd":"add","args":["Task 1","--meta","source=api"]}
+{"cmd":"done","args":["3"]}' | rondo batch
 
 # Utilities
 rondo stats
@@ -321,6 +342,8 @@ internal/
     errors.go                   # NotFoundError type
     confirm.go                  # Confirmation prompts
     tasks.go                    # add, done, list, show, edit, delete, status
+    batch.go                    # batch (stdin newline-delimited JSON commands)
+    note.go                     # note (add, list, edit, delete)
     journal.go                  # journal (add, list, show, edit, delete, hide)
     export.go                   # export (md, json, file output)
     subtasks.go                 # subtask (add, list, done, edit, delete)

--- a/internal/app/delegate.go
+++ b/internal/app/delegate.go
@@ -114,6 +114,12 @@ func (d taskDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 		}
 		subtitle += lipgloss.NewStyle().Foreground(ui.Gray).Render(fmt.Sprintf("[%d/%d]", done, len(t.Subtasks)))
 	}
+	if len(t.Notes) > 0 {
+		if subtitle != "" {
+			subtitle += "  "
+		}
+		subtitle += lipgloss.NewStyle().Foreground(ui.Gray).Render(fmt.Sprintf("[%d notes]", len(t.Notes)))
+	}
 	line2 := lipgloss.NewStyle().PaddingLeft(5).MaxWidth(availWidth).Render(subtitle)
 
 	// Cursor / selection

--- a/internal/app/keys.go
+++ b/internal/app/keys.go
@@ -28,6 +28,7 @@ type keyMap struct {
 	Undo          key.Binding
 	Stats         key.Binding
 	Blocker       key.Binding
+	Note          key.Binding
 	FocusSettings key.Binding
 }
 
@@ -129,6 +130,10 @@ var keys = keyMap{
 	Blocker: key.NewBinding(
 		key.WithKeys("b"),
 		key.WithHelp("b", "blockers"),
+	),
+	Note: key.NewBinding(
+		key.WithKeys("n"),
+		key.WithHelp("n", "notes"),
 	),
 	FocusSettings: key.NewBinding(
 		key.WithKeys("P"),

--- a/internal/app/model.go
+++ b/internal/app/model.go
@@ -42,9 +42,12 @@ const (
 	modeTagFilter
 	modeStats
 	modeBlockerPicker
-	modeFocusSessionEnd // work done overlay
-	modeFocusBreakEnd   // break done overlay
-	modeFocusSettings   // P key settings form
+	modeNoteAdd              // task note add form
+	modeNoteEdit             // task note edit form
+	modeConfirmDeleteNote    // task note delete confirmation
+	modeFocusSessionEnd      // work done overlay
+	modeFocusBreakEnd        // break done overlay
+	modeFocusSettings        // P key settings form
 )
 
 const tabCount = 4
@@ -120,6 +123,11 @@ type Model struct {
 
 	// Time log.
 	timeLogFormData *ui.TimeLogFormData
+
+	// Notes (detail panel).
+	noteIdx      int
+	notesFocused bool
+	noteFormData *ui.NoteFormData
 
 	// Focus settings form.
 	focusSettingsFormData *ui.FocusSettingsData
@@ -258,6 +266,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	if m.mode == modeTimeLog {
 		return m.updateTimeLogForm(msg)
 	}
+	if m.mode == modeNoteAdd || m.mode == modeNoteEdit {
+		return m.updateNoteForm(msg)
+	}
 	if m.mode == modeFocusSettings {
 		return m.updateFocusSettingsForm(msg)
 	}
@@ -321,6 +332,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		if m.mode == modeConfirmDeleteSubtask {
 			return m.updateConfirmDeleteSubtask(msg)
+		}
+		if m.mode == modeConfirmDeleteNote {
+			return m.updateConfirmDeleteNote(msg)
 		}
 		if m.mode == modeJournalConfirmHide {
 			return m.updateJournalConfirmHide(msg)
@@ -460,74 +474,140 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// When detail panel is focused, keys operate on subtasks.
+		// When detail panel is focused, keys operate on subtasks or notes.
 		if m.focusedPanel == 1 {
 			selected := m.selectedTask()
-			switch msg.String() {
-			case "j", "down":
-				if selected != nil && len(selected.Subtasks) > 0 {
-					if m.subtaskIdx < len(selected.Subtasks)-1 {
-						m.subtaskIdx++
+
+			// Note mode: n toggles between subtask and note navigation.
+			if key.Matches(msg, keys.Note) {
+				if selected != nil {
+					m.notesFocused = !m.notesFocused
+					if m.notesFocused {
+						m.noteIdx = 0
 					}
-					m.updateDetail()
-				}
-				return m, nil
-			case "k", "up":
-				if m.subtaskIdx > 0 {
-					m.subtaskIdx--
 					m.updateDetail()
 				}
 				return m, nil
 			}
-			// Context-sensitive: a/e/d/s operate on subtasks when detail is focused.
-			switch {
-			case key.Matches(msg, keys.Add):
-				if selected != nil {
-					m.formData = &ui.TaskFormData{}
-					m.form = ui.SubtaskForm(&m.formData.Title)
-					m.mode = modeSubtask
-					return m, m.form.Init()
-				}
+
+			// Esc in note focus returns to subtask focus (not panel 1).
+			if m.notesFocused && msg.String() == "esc" {
+				m.notesFocused = false
+				m.updateDetail()
 				return m, nil
-			case key.Matches(msg, keys.Edit):
-				if selected != nil && m.subtaskIdx >= 0 && m.subtaskIdx < len(selected.Subtasks) {
-					st := selected.Subtasks[m.subtaskIdx]
-					m.formData = &ui.TaskFormData{Title: st.Title}
-					m.form = ui.SubtaskForm(&m.formData.Title)
-					m.mode = modeEditSubtask
-					return m, m.form.Init()
-				}
-				return m, nil
-			case key.Matches(msg, keys.Delete):
-				if selected != nil && m.subtaskIdx >= 0 && m.subtaskIdx < len(selected.Subtasks) {
-					m.mode = modeConfirmDeleteSubtask
-				}
-				return m, nil
-			case key.Matches(msg, keys.Status):
-				if selected != nil && m.subtaskIdx >= 0 && m.subtaskIdx < len(selected.Subtasks) {
-					st := selected.Subtasks[m.subtaskIdx]
-					if err := m.store.ToggleSubtask(st.ID); err != nil {
-						return m, m.setError(err)
+			}
+
+			// When notes are focused, operate on notes.
+			if m.notesFocused {
+				switch msg.String() {
+				case "j", "down":
+					if selected != nil && len(selected.Notes) > 0 {
+						if m.noteIdx < len(selected.Notes)-1 {
+							m.noteIdx++
+						}
+						m.updateDetail()
 					}
-					if err := m.reload(); err != nil {
-						return m, m.setError(err)
+					return m, nil
+				case "k", "up":
+					if m.noteIdx > 0 {
+						m.noteIdx--
+						m.updateDetail()
 					}
-					return m, m.setStatus("Subtask toggled")
+					return m, nil
 				}
-				return m, nil
-			case key.Matches(msg, keys.TimeLog):
-				if selected != nil {
-					m.timeLogFormData = &ui.TimeLogFormData{}
-					m.form = ui.TimeLogForm(m.timeLogFormData)
-					m.mode = modeTimeLog
-					return m, m.form.Init()
+				switch {
+				case key.Matches(msg, keys.Add):
+					if selected != nil {
+						m.noteFormData = &ui.NoteFormData{}
+						m.form = ui.NoteForm(m.noteFormData)
+						m.mode = modeNoteAdd
+						return m, m.form.Init()
+					}
+					return m, nil
+				case key.Matches(msg, keys.Edit):
+					if selected != nil && m.noteIdx >= 0 && m.noteIdx < len(selected.Notes) {
+						n := selected.Notes[m.noteIdx]
+						m.noteFormData = &ui.NoteFormData{Body: n.Body}
+						m.form = ui.NoteForm(m.noteFormData)
+						m.mode = modeNoteEdit
+						return m, m.form.Init()
+					}
+					return m, nil
+				case key.Matches(msg, keys.Delete):
+					if selected != nil && m.noteIdx >= 0 && m.noteIdx < len(selected.Notes) {
+						m.mode = modeConfirmDeleteNote
+					}
+					return m, nil
 				}
-				return m, nil
-			case key.Matches(msg, keys.Blocker):
-				if selected != nil {
-					m.mode = modeBlockerPicker
+				// Fall through for global keys (q, ?, Tab, etc.)
+			} else {
+				// Subtask navigation (default detail panel behavior).
+				switch msg.String() {
+				case "j", "down":
+					if selected != nil && len(selected.Subtasks) > 0 {
+						if m.subtaskIdx < len(selected.Subtasks)-1 {
+							m.subtaskIdx++
+						}
+						m.updateDetail()
+					}
+					return m, nil
+				case "k", "up":
+					if m.subtaskIdx > 0 {
+						m.subtaskIdx--
+						m.updateDetail()
+					}
+					return m, nil
 				}
-				return m, nil
+				// Context-sensitive: a/e/d/s operate on subtasks when detail is focused.
+				switch {
+				case key.Matches(msg, keys.Add):
+					if selected != nil {
+						m.formData = &ui.TaskFormData{}
+						m.form = ui.SubtaskForm(&m.formData.Title)
+						m.mode = modeSubtask
+						return m, m.form.Init()
+					}
+					return m, nil
+				case key.Matches(msg, keys.Edit):
+					if selected != nil && m.subtaskIdx >= 0 && m.subtaskIdx < len(selected.Subtasks) {
+						st := selected.Subtasks[m.subtaskIdx]
+						m.formData = &ui.TaskFormData{Title: st.Title}
+						m.form = ui.SubtaskForm(&m.formData.Title)
+						m.mode = modeEditSubtask
+						return m, m.form.Init()
+					}
+					return m, nil
+				case key.Matches(msg, keys.Delete):
+					if selected != nil && m.subtaskIdx >= 0 && m.subtaskIdx < len(selected.Subtasks) {
+						m.mode = modeConfirmDeleteSubtask
+					}
+					return m, nil
+				case key.Matches(msg, keys.Status):
+					if selected != nil && m.subtaskIdx >= 0 && m.subtaskIdx < len(selected.Subtasks) {
+						st := selected.Subtasks[m.subtaskIdx]
+						if err := m.store.ToggleSubtask(st.ID); err != nil {
+							return m, m.setError(err)
+						}
+						if err := m.reload(); err != nil {
+							return m, m.setError(err)
+						}
+						return m, m.setStatus("Subtask toggled")
+					}
+					return m, nil
+				case key.Matches(msg, keys.TimeLog):
+					if selected != nil {
+						m.timeLogFormData = &ui.TimeLogFormData{}
+						m.form = ui.TimeLogForm(m.timeLogFormData)
+						m.mode = modeTimeLog
+						return m, m.form.Init()
+					}
+					return m, nil
+				case key.Matches(msg, keys.Blocker):
+					if selected != nil {
+						m.mode = modeBlockerPicker
+					}
+					return m, nil
+				}
 			}
 			// Other keys (q, ?, Tab, /, F1-F3) fall through to normal handling.
 		}
@@ -550,6 +630,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				dueStr = selected.DueDate.Format(time.DateOnly)
 			}
 			recurFreq := selected.RecurFreq.String()
+			// Format metadata as "key=value, key2=value2".
+			var metaParts []string
+			for k, v := range selected.Metadata {
+				metaParts = append(metaParts, k+"="+v)
+			}
+			// Format blocks as "1, 2, 3" (task IDs this task blocks).
+			var blocksParts []string
+			for _, bid := range selected.BlocksIDs {
+				blocksParts = append(blocksParts, strconv.FormatInt(bid, 10))
+			}
 			m.formData = &ui.TaskFormData{
 				Title:       selected.Title,
 				Description: selected.Description,
@@ -557,6 +647,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				DueDate:     dueStr,
 				Tags:        strings.Join(selected.Tags, ", "),
 				RecurFreq:   recurFreq,
+				Metadata:    strings.Join(metaParts, ", "),
+				Blocks:      strings.Join(blocksParts, ", "),
 			}
 			m.form = ui.EditTaskForm(m.formData)
 			m.mode = modeEdit
@@ -658,6 +750,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.list, cmd = m.list.Update(msg)
 		if m.list.Index() != prevIndex {
 			m.subtaskIdx = 0
+			m.noteIdx = 0
+			m.notesFocused = false
 			m.updateDetail()
 		}
 		m.list.SetShowFilter(m.list.FilterState() == list.Filtering || m.list.FilterState() == list.FilterApplied)
@@ -754,7 +848,7 @@ func (m Model) View() string {
 	timerStr := m.focusTimerStr()
 
 	// Status bar.
-	statusBar := ui.RenderStatusBar(allCount, doneCount, activeCount, m.width, m.statusMsg, m.focusedPanel, m.activeTab, timerStr, m.undoAction != nil)
+	statusBar := ui.RenderStatusBar(allCount, doneCount, activeCount, m.width, m.statusMsg, m.focusedPanel, m.activeTab, timerStr, m.undoAction != nil, m.notesFocused)
 
 	// Combine all sections.
 	var sections []string
@@ -814,6 +908,34 @@ func (m Model) View() string {
 				lipgloss.WithWhitespaceChars(" "),
 				lipgloss.WithWhitespaceForeground(ui.OverlayDim))
 		}
+
+	case modeNoteAdd, modeNoteEdit:
+		if m.form != nil {
+			title := "Add Note"
+			if m.mode == modeNoteEdit {
+				title = "Edit Note"
+			}
+			formView := m.form.View()
+			dialogContent := lipgloss.NewStyle().Bold(true).Foreground(ui.White).Render(title) + "\n\n" + formView
+			dialog := dialogStyle().Render(dialogContent)
+			view = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, dialog,
+				lipgloss.WithWhitespaceChars(" "),
+				lipgloss.WithWhitespaceForeground(ui.OverlayDim))
+		}
+
+	case modeConfirmDeleteNote:
+		selected := m.selectedTask()
+		noteBody := ""
+		if selected != nil && m.noteIdx >= 0 && m.noteIdx < len(selected.Notes) {
+			noteBody = selected.Notes[m.noteIdx].Body
+			if len(noteBody) > 50 {
+				noteBody = noteBody[:50] + "..."
+			}
+		}
+		dialog := ui.RenderConfirmDialogBox("Delete Note?", fmt.Sprintf("Delete \"%s\"?", noteBody))
+		view = lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, dialog,
+			lipgloss.WithWhitespaceChars(" "),
+			lipgloss.WithWhitespaceForeground(ui.OverlayDim))
 
 	case modeFocusSettings:
 		if m.form != nil {

--- a/internal/app/model_forms.go
+++ b/internal/app/model_forms.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -165,6 +166,112 @@ func (m *Model) updateTimeLogForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, cmd
 }
 
+func (m *Model) updateNoteForm(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if wsm, ok := msg.(tea.WindowSizeMsg); ok {
+		m.width = wsm.Width
+		m.height = wsm.Height
+		m.resizeComponents()
+	}
+	if keyMsg, ok := msg.(tea.KeyMsg); ok && keyMsg.String() == "esc" {
+		m.mode = modeNormal
+		m.form = nil
+		m.noteFormData = nil
+		return m, nil
+	}
+
+	form, cmd := m.form.Update(msg)
+	if f, ok := form.(*huh.Form); ok {
+		m.form = f
+		if m.form.State == huh.StateCompleted {
+			wasEdit := m.mode == modeNoteEdit
+			selected := m.selectedTask()
+			if selected != nil && m.noteFormData != nil {
+				body := strings.TrimSpace(m.noteFormData.Body)
+				if body != "" {
+					if !wasEdit {
+						if err := m.store.AddNote(selected.ID, body); err != nil {
+							m.mode = modeNormal
+							m.form = nil
+							m.noteFormData = nil
+							return m, m.setError(err)
+						}
+					} else {
+						if m.noteIdx >= 0 && m.noteIdx < len(selected.Notes) {
+							n := selected.Notes[m.noteIdx]
+							if err := m.store.UpdateNote(n.ID, body); err != nil {
+								m.mode = modeNormal
+								m.form = nil
+								m.noteFormData = nil
+								return m, m.setError(err)
+							}
+						}
+					}
+				}
+			}
+			m.mode = modeNormal
+			m.form = nil
+			m.noteFormData = nil
+			if err := m.reload(); err != nil {
+				return m, m.setError(err)
+			}
+			if wasEdit {
+				return m, m.setStatus("Note updated")
+			}
+			return m, m.setStatus("Note added")
+		}
+		if m.form.State == huh.StateAborted {
+			m.mode = modeNormal
+			m.form = nil
+			m.noteFormData = nil
+			return m, nil
+		}
+	}
+	return m, cmd
+}
+
+func (m *Model) updateConfirmDeleteNote(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "y", "Y":
+		selected := m.selectedTask()
+		if selected != nil && m.noteIdx >= 0 && m.noteIdx < len(selected.Notes) {
+			n := selected.Notes[m.noteIdx]
+			// Capture for undo.
+			taskID := selected.ID
+			noteBody := n.Body
+			noteCreatedAt := n.CreatedAt
+			m.undoAction = &undoAction{
+				description: fmt.Sprintf("Undo delete note %q", truncate(noteBody, 30)),
+				undo: func() error {
+					return m.store.RestoreNote(taskID, noteBody, noteCreatedAt)
+				},
+			}
+			if err := m.store.DeleteNote(n.ID); err != nil {
+				m.mode = modeNormal
+				return m, m.setError(err)
+			}
+			if m.noteIdx > 0 && m.noteIdx >= len(selected.Notes)-1 {
+				m.noteIdx--
+			}
+			if err := m.reload(); err != nil {
+				m.mode = modeNormal
+				return m, m.setError(err)
+			}
+		}
+		m.mode = modeNormal
+		return m, m.setStatus("Note deleted")
+	case "n", "N", "esc":
+		m.mode = modeNormal
+	}
+	return m, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "..."
+}
+
 func (m *Model) updateConfirmDelete(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	switch msg.String() {
 	case "y", "Y":
@@ -268,6 +375,40 @@ func (m *Model) submitTaskForm() tea.Cmd {
 
 	recurFreq := task.ParseRecurFreq(m.formData.RecurFreq)
 
+	// Parse metadata.
+	metadata := make(map[string]string)
+	if m.formData.Metadata != "" {
+		for _, pair := range strings.Split(m.formData.Metadata, ",") {
+			pair = strings.TrimSpace(pair)
+			if pair == "" {
+				continue
+			}
+			parts := strings.SplitN(pair, "=", 2)
+			if len(parts) == 2 {
+				k := strings.TrimSpace(parts[0])
+				v := strings.TrimSpace(parts[1])
+				if k != "" {
+					metadata[k] = v
+				}
+			}
+		}
+	}
+
+	// Parse blocks.
+	var blocksIDs []int64
+	if m.formData.Blocks != "" {
+		for _, part := range strings.Split(m.formData.Blocks, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			id, err := strconv.ParseInt(part, 10, 64)
+			if err == nil && id > 0 {
+				blocksIDs = append(blocksIDs, id)
+			}
+		}
+	}
+
 	var statusCmd tea.Cmd
 	if m.mode == modeAdd {
 		t := &task.Task{
@@ -278,12 +419,19 @@ func (m *Model) submitTaskForm() tea.Cmd {
 			Tags:          tags,
 			RecurFreq:     recurFreq,
 			RecurInterval: 1,
+			Metadata:      metadata,
 		}
 		if err := m.store.Create(t); err != nil {
 			statusCmd = m.setError(err)
 		} else {
 			if recurFreq != task.RecurNone {
 				_ = m.store.UpdateRecurrence(t.ID, recurFreq, 1)
+			}
+			if len(blocksIDs) > 0 {
+				// This task blocks the listed tasks.
+				for _, blockedID := range blocksIDs {
+					_ = m.store.SetBlocker(blockedID, t.ID)
+				}
 			}
 			statusCmd = m.setStatus("Task created")
 		}
@@ -296,6 +444,7 @@ func (m *Model) submitTaskForm() tea.Cmd {
 			selected.DueDate = dueDate
 			selected.Tags = tags
 			selected.RecurFreq = recurFreq
+			selected.Metadata = metadata
 			if recurFreq != task.RecurNone && selected.RecurInterval == 0 {
 				selected.RecurInterval = 1
 			}
@@ -303,6 +452,16 @@ func (m *Model) submitTaskForm() tea.Cmd {
 				statusCmd = m.setError(err)
 			} else {
 				_ = m.store.UpdateRecurrence(selected.ID, recurFreq, selected.RecurInterval)
+				// Update blocks: clear old, set new.
+				// "Blocks" means this task blocks the listed task IDs.
+				// First remove old "blocks" relationships where this task was the blocker.
+				oldBlocks := selected.BlocksIDs
+				for _, bid := range oldBlocks {
+					_ = m.store.RemoveBlocker(bid, selected.ID)
+				}
+				for _, blockedID := range blocksIDs {
+					_ = m.store.SetBlocker(blockedID, selected.ID)
+				}
 				statusCmd = m.setStatus("Task updated")
 			}
 		}

--- a/internal/app/model_journal.go
+++ b/internal/app/model_journal.go
@@ -414,7 +414,7 @@ func (m Model) viewJournal(header string) string {
 		}
 	}
 	timerStr := m.focusTimerStr()
-	statusBar := ui.RenderStatusBar(noteCount, todayEntryCount, 0, m.width, m.statusMsg, m.focusedPanel, 3, timerStr, m.undoAction != nil)
+	statusBar := ui.RenderStatusBar(noteCount, todayEntryCount, 0, m.width, m.statusMsg, m.focusedPanel, 3, timerStr, m.undoAction != nil, false)
 
 	return lipgloss.JoinVertical(lipgloss.Left, header, content, statusBar)
 }

--- a/internal/app/model_overlays.go
+++ b/internal/app/model_overlays.go
@@ -108,22 +108,43 @@ func (m Model) renderBlockerOverlay() string {
 	lines = append(lines, lipgloss.NewStyle().Foreground(ui.Gray).Render(fmt.Sprintf("Task: %s", selected.Title)))
 	lines = append(lines, "")
 
-	if len(selected.BlockedByIDs) == 0 {
-		lines = append(lines, lipgloss.NewStyle().Foreground(ui.Gray).Render("No blockers"))
+	if len(selected.BlockedByIDs) == 0 && len(selected.BlocksIDs) == 0 {
+		lines = append(lines, lipgloss.NewStyle().Foreground(ui.Gray).Render("No dependencies"))
 	} else {
-		lines = append(lines, lipgloss.NewStyle().Bold(true).Foreground(ui.Cyan).Render("Blocked by:"))
-		for _, id := range selected.BlockedByIDs {
-			blocker, err := m.store.GetByID(id)
-			if err != nil {
-				lines = append(lines, fmt.Sprintf("  - Task #%d (not found)", id))
-				continue
+		if len(selected.BlockedByIDs) > 0 {
+			lines = append(lines, lipgloss.NewStyle().Bold(true).Foreground(ui.Cyan).Render("Blocked by:"))
+			for _, id := range selected.BlockedByIDs {
+				blocker, err := m.store.GetByID(id)
+				if err != nil {
+					lines = append(lines, fmt.Sprintf("  - Task #%d (not found)", id))
+					continue
+				}
+				statusIcon := blocker.Status.Icon()
+				style := lipgloss.NewStyle().Foreground(ui.White)
+				if blocker.Status == task.Done {
+					style = style.Foreground(ui.Green)
+				}
+				lines = append(lines, style.Render(fmt.Sprintf("  %s %s", statusIcon, blocker.Title)))
 			}
-			statusIcon := blocker.Status.Icon()
-			style := lipgloss.NewStyle().Foreground(ui.White)
-			if blocker.Status == task.Done {
-				style = style.Foreground(ui.Green)
+		}
+		if len(selected.BlocksIDs) > 0 {
+			if len(selected.BlockedByIDs) > 0 {
+				lines = append(lines, "")
 			}
-			lines = append(lines, style.Render(fmt.Sprintf("  %s %s", statusIcon, blocker.Title)))
+			lines = append(lines, lipgloss.NewStyle().Bold(true).Foreground(ui.Cyan).Render("Blocks:"))
+			for _, id := range selected.BlocksIDs {
+				blocked, err := m.store.GetByID(id)
+				if err != nil {
+					lines = append(lines, fmt.Sprintf("  - Task #%d (not found)", id))
+					continue
+				}
+				statusIcon := blocked.Status.Icon()
+				style := lipgloss.NewStyle().Foreground(ui.White)
+				if blocked.Status == task.Done {
+					style = style.Foreground(ui.Green)
+				}
+				lines = append(lines, style.Render(fmt.Sprintf("  %s %s", statusIcon, blocked.Title)))
+			}
 		}
 	}
 
@@ -271,6 +292,7 @@ func (m Model) renderHelpOverlay() string {
 		{"F1/F2/F3", "Sort date / due / priority"},
 		{"F4", "Tag filter bar"},
 		{"l", "Log time (detail)"},
+		{"n", "Notes (detail)"},
 		{"b", "View blockers (detail)"},
 		{"", ""},
 		{"", "Tools"},

--- a/internal/app/model_tasks.go
+++ b/internal/app/model_tasks.go
@@ -112,7 +112,13 @@ func (m *Model) updateDetail() {
 	} else if m.subtaskIdx >= len(selected.Subtasks) {
 		m.subtaskIdx = len(selected.Subtasks) - 1
 	}
-	content := ui.RenderDetail(selected, m.viewport.Width, m.subtaskIdx, m.focusedPanel == 1)
+	// Clamp noteIdx to valid range.
+	if selected == nil || len(selected.Notes) == 0 {
+		m.noteIdx = 0
+	} else if m.noteIdx >= len(selected.Notes) {
+		m.noteIdx = len(selected.Notes) - 1
+	}
+	content := ui.RenderDetail(selected, m.viewport.Width, m.subtaskIdx, m.focusedPanel == 1, m.noteIdx, m.notesFocused)
 	m.viewport.SetContent(content)
 	m.viewport.GotoTop()
 }

--- a/internal/cli/batch.go
+++ b/internal/cli/batch.go
@@ -1,0 +1,76 @@
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// batchCommand is a single command in a batch request.
+type batchCommand struct {
+	Cmd  string   `json:"cmd"`
+	Args []string `json:"args,omitempty"`
+}
+
+// batchResult is the result of a single command in a batch.
+type batchResult struct {
+	Cmd   string `json:"cmd"`
+	OK    bool   `json:"ok"`
+	Error string `json:"error,omitempty"`
+}
+
+func (c *CLI) batchCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "batch",
+		Short: "Execute commands from stdin (one JSON object per line)",
+		Long: `Read newline-delimited JSON commands from stdin and execute each one.
+Each line is a JSON object: {"cmd": "add", "args": ["task title", "--priority", "high"]}
+Output is a JSON array of results.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			scanner := bufio.NewScanner(os.Stdin)
+			var results []batchResult
+
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if line == "" {
+					continue
+				}
+
+				var bc batchCommand
+				if err := json.Unmarshal([]byte(line), &bc); err != nil {
+					results = append(results, batchResult{
+						Cmd:   line,
+						OK:    false,
+						Error: fmt.Sprintf("invalid JSON: %v", err),
+					})
+					continue
+				}
+
+				// Build a fresh command tree for each command to avoid
+				// cobra flag state leaking between invocations.
+				fresh := New(c.taskStore, c.journalStore, c.focusStore, c.cfg)
+				fresh.SetArgs(append([]string{bc.Cmd}, bc.Args...))
+				err := fresh.Execute()
+
+				br := batchResult{Cmd: bc.Cmd, OK: err == nil}
+				if err != nil {
+					br.Error = err.Error()
+				}
+				results = append(results, br)
+			}
+
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("read stdin: %w", err)
+			}
+
+			enc := json.NewEncoder(os.Stdout)
+			enc.SetIndent("", "  ")
+			return enc.Encode(results)
+		},
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -83,6 +83,8 @@ func New(ts *task.Store, js *journal.Store, fs *focus.Store, cfg config.Config) 
 	root.AddCommand(c.configCmd())
 	root.AddCommand(c.statsCmd())
 	root.AddCommand(c.focusCmd())
+	root.AddCommand(c.noteCmd())
+	root.AddCommand(c.batchCmd())
 	root.AddCommand(c.completionCmd())
 
 	return root

--- a/internal/cli/journal.go
+++ b/internal/cli/journal.go
@@ -18,11 +18,11 @@ import (
 func parseJournalDate(s string) (string, error) {
 	switch strings.ToLower(s) {
 	case "today", "":
-		return time.Now().Format(time.DateOnly), nil
+		return time.Now().UTC().Format(time.DateOnly), nil
 	case "yesterday":
-		return time.Now().AddDate(0, 0, -1).Format(time.DateOnly), nil
+		return time.Now().UTC().AddDate(0, 0, -1).Format(time.DateOnly), nil
 	default:
-		t, err := time.ParseInLocation(time.DateOnly, s, time.Local)
+		t, err := time.ParseInLocation(time.DateOnly, s, time.UTC)
 		if err != nil {
 			return "", fmt.Errorf("invalid date %q: expected today, yesterday, or YYYY-MM-DD", s)
 		}

--- a/internal/cli/note.go
+++ b/internal/cli/note.go
@@ -1,0 +1,193 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/roniel/todo-app/internal/task"
+	"github.com/spf13/cobra"
+)
+
+func (c *CLI) noteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "note",
+		Short: "Manage task notes",
+	}
+	cmd.AddCommand(
+		c.noteAddCmd(),
+		c.noteListCmd(),
+		c.noteEditCmd(),
+		c.noteDeleteCmd(),
+	)
+	return cmd
+}
+
+func (c *CLI) noteAddCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "add <task-id> \"note text\"",
+		Short: "Add a note to a task",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			taskID, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid task ID %q: %w", args[0], err)
+			}
+			if _, err := c.getTaskOrNotFound(taskID); err != nil {
+				return err
+			}
+			body := args[1]
+			if err := c.taskStore.AddNote(taskID, body); err != nil {
+				return fmt.Errorf("add note: %w", err)
+			}
+			c.printer(os.Stdout).Success("Added note to task #%d", taskID)
+			return nil
+		},
+	}
+}
+
+func (c *CLI) noteListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list <task-id>",
+		Short: "List notes for a task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			taskID, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid task ID %q: %w", args[0], err)
+			}
+			if _, err := c.getTaskOrNotFound(taskID); err != nil {
+				return err
+			}
+			notes, err := c.taskStore.ListNotes(taskID)
+			if err != nil {
+				return fmt.Errorf("list notes: %w", err)
+			}
+			p := c.printer(os.Stdout)
+			if strings.ToLower(c.format) == "json" {
+				type jsonN struct {
+					ID        int64  `json:"id"`
+					Body      string `json:"body"`
+					CreatedAt string `json:"created_at"`
+				}
+				out := make([]jsonN, 0, len(notes))
+				for _, n := range notes {
+					out = append(out, jsonN{
+						ID:        n.ID,
+						Body:      n.Body,
+						CreatedAt: n.CreatedAt.Format(time.RFC3339),
+					})
+				}
+				return p.JSON(out)
+			}
+			rows := make([][]string, 0, len(notes))
+			for _, n := range notes {
+				rows = append(rows, []string{
+					strconv.FormatInt(n.ID, 10),
+					n.CreatedAt.Format("2006-01-02 15:04"),
+					n.Body,
+				})
+			}
+			p.Table([]string{"ID", "DATE", "NOTE"}, rows)
+			return nil
+		},
+	}
+}
+
+func (c *CLI) noteEditCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "edit <task-id> <note-id> \"new text\"",
+		Short: "Edit a note",
+		Args:  cobra.ExactArgs(3),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			taskID, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid task ID %q: %w", args[0], err)
+			}
+			noteID, err := strconv.ParseInt(args[1], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid note ID %q: %w", args[1], err)
+			}
+			newBody := args[2]
+			t, err := c.getTaskOrNotFound(taskID)
+			if err != nil {
+				return err
+			}
+			if !noteBelongsToTask(t, noteID) {
+				return &NotFoundError{Type: "note", ID: noteID}
+			}
+			if err := c.taskStore.UpdateNote(noteID, newBody); err != nil {
+				return fmt.Errorf("update note: %w", err)
+			}
+			c.printer(os.Stdout).Success("Updated note #%d", noteID)
+			return nil
+		},
+	}
+}
+
+func (c *CLI) noteDeleteCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "delete <task-id> <note-id>",
+		Short: "Delete a note",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			taskID, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid task ID %q: %w", args[0], err)
+			}
+			noteID, err := strconv.ParseInt(args[1], 10, 64)
+			if err != nil {
+				return fmt.Errorf("invalid note ID %q: %w", args[1], err)
+			}
+			t, err := c.getTaskOrNotFound(taskID)
+			if err != nil {
+				return err
+			}
+			var noteBody string
+			found := false
+			for _, n := range t.Notes {
+				if n.ID == noteID {
+					noteBody = n.Body
+					found = true
+					break
+				}
+			}
+			if !found {
+				return &NotFoundError{Type: "note", ID: noteID}
+			}
+			// Truncate body for confirmation prompt
+			display := noteBody
+			if len(display) > 50 {
+				display = display[:50] + "..."
+			}
+			ok, err := Confirm(fmt.Sprintf("Delete note #%d %q?", noteID, display), force)
+			if err != nil {
+				return err
+			}
+			if !ok {
+				fmt.Fprintln(os.Stderr, "Cancelled.")
+				return nil
+			}
+			if err := c.taskStore.DeleteNote(noteID); err != nil {
+				return fmt.Errorf("delete note: %w", err)
+			}
+			c.printer(os.Stdout).Success("Deleted note #%d", noteID)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&force, "force", "y", false, "Skip confirmation prompt")
+	return cmd
+}
+
+// noteBelongsToTask reports whether noteID is among the task's notes.
+func noteBelongsToTask(t *task.Task, noteID int64) bool {
+	for _, n := range t.Notes {
+		if n.ID == noteID {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/tasks.go
+++ b/internal/cli/tasks.go
@@ -44,8 +44,46 @@ func (c *CLI) getTaskOrNotFound(id int64) (*task.Task, error) {
 	return t, nil
 }
 
+// parseMetaFlags parses --meta key=value pairs into a map.
+func parseMetaFlags(raw []string) (map[string]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	m := make(map[string]string, len(raw))
+	for _, kv := range raw {
+		eq := strings.IndexByte(kv, '=')
+		if eq < 1 {
+			return nil, fmt.Errorf("invalid --meta %q: expected key=value", kv)
+		}
+		m[kv[:eq]] = kv[eq+1:]
+	}
+	return m, nil
+}
+
+// parseBlocksFlag parses a comma-separated list of task IDs.
+func parseBlocksFlag(s string) ([]int64, error) {
+	if s == "" {
+		return nil, nil
+	}
+	parts := strings.Split(s, ",")
+	ids := make([]int64, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		id, err := strconv.ParseInt(p, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid task ID %q in --blocks: %w", p, err)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
+}
+
 func (c *CLI) addCmd() *cobra.Command {
-	var priority, due, tags, desc, recur string
+	var priority, due, tags, desc, recur, blocks string
+	var meta []string
 
 	cmd := &cobra.Command{
 		Use:   "add \"task title\" [flags]",
@@ -62,7 +100,7 @@ func (c *CLI) addCmd() *cobra.Command {
 			t.Priority = prio
 
 			if due != "" {
-				d, err := time.ParseInLocation(time.DateOnly, due, time.Local)
+				d, err := time.ParseInLocation(time.DateOnly, due, time.UTC)
 				if err != nil {
 					return fmt.Errorf("invalid due date %q: expected YYYY-MM-DD", due)
 				}
@@ -78,8 +116,27 @@ func (c *CLI) addCmd() *cobra.Command {
 				}
 			}
 
+			if m, err := parseMetaFlags(meta); err != nil {
+				return err
+			} else {
+				t.Metadata = m
+			}
+
 			if err := c.taskStore.Create(t); err != nil {
 				return fmt.Errorf("create task: %w", err)
+			}
+
+			// Set blockers: this task blocks the listed task IDs
+			if blocks != "" {
+				blockerIDs, err := parseBlocksFlag(blocks)
+				if err != nil {
+					return err
+				}
+				for _, bid := range blockerIDs {
+					if err := c.taskStore.SetBlocker(bid, t.ID); err != nil {
+						return fmt.Errorf("set blocker: %w", err)
+					}
+				}
 			}
 
 			if recur != "" && strings.ToLower(recur) != "none" {
@@ -106,6 +163,8 @@ func (c *CLI) addCmd() *cobra.Command {
 	cmd.Flags().StringVar(&tags, "tags", "", "Comma-separated tags")
 	cmd.Flags().StringVar(&desc, "desc", "", "Task description")
 	cmd.Flags().StringVar(&recur, "recur", "", "Recurrence: daily, weekly, monthly, yearly")
+	cmd.Flags().StringSliceVar(&meta, "meta", nil, "Metadata key=value (repeatable: --meta source=whatsapp --meta group=main)")
+	cmd.Flags().StringVar(&blocks, "blocks", "", "Comma-separated task IDs this task blocks")
 
 	return cmd
 }
@@ -181,7 +240,7 @@ func (c *CLI) showCmd() *cobra.Command {
 
 			switch strings.ToLower(c.format) {
 			case "json":
-				return printTaskJSON(os.Stdout, t)
+				return c.printTaskJSON(os.Stdout, t)
 			default:
 				return printTaskDetail(c.printer(os.Stdout), t)
 			}
@@ -190,8 +249,9 @@ func (c *CLI) showCmd() *cobra.Command {
 }
 
 func (c *CLI) editCmd() *cobra.Command {
-	var title, desc, priority, due, tags, recur string
-	var clearDue bool
+	var title, desc, priority, due, tags, recur, blocks string
+	var clearDue, clearBlocks bool
+	var meta []string
 
 	cmd := &cobra.Command{
 		Use:   "edit <task-id> [flags]",
@@ -230,7 +290,7 @@ func (c *CLI) editCmd() *cobra.Command {
 				t.DueDate = nil
 				changed = true
 			} else if cmd.Flags().Changed("due") {
-				d, err := time.ParseInLocation(time.DateOnly, due, time.Local)
+				d, err := time.ParseInLocation(time.DateOnly, due, time.UTC)
 				if err != nil {
 					return fmt.Errorf("invalid due date %q: expected YYYY-MM-DD", due)
 				}
@@ -247,15 +307,62 @@ func (c *CLI) editCmd() *cobra.Command {
 				}
 				changed = true
 			}
+			if cmd.Flags().Changed("meta") {
+				newMeta, err := parseMetaFlags(meta)
+				if err != nil {
+					return err
+				}
+				if t.Metadata == nil {
+					t.Metadata = make(map[string]string)
+				}
+				for k, v := range newMeta {
+					t.Metadata[k] = v
+				}
+				changed = true
+			}
 
+			blocksChanged := clearBlocks || cmd.Flags().Changed("blocks")
 			recurChanged := cmd.Flags().Changed("recur")
-			if !changed && !recurChanged {
-				return fmt.Errorf("no changes specified: use --title, --desc, --priority, --due, --tags, --recur, or --clear-due")
+			if !changed && !recurChanged && !blocksChanged {
+				return fmt.Errorf("no changes specified: use --title, --desc, --priority, --due, --tags, --meta, --blocks, --recur, --clear-due, or --clear-blocks")
 			}
 
 			if changed {
 				if err := c.taskStore.Update(t); err != nil {
 					return fmt.Errorf("update task: %w", err)
+				}
+			}
+
+			if clearBlocks {
+				// Clear all tasks that this task blocks
+				blocksIDs, err := c.taskStore.ListBlocksIDs(id)
+				if err != nil {
+					return fmt.Errorf("list blocks: %w", err)
+				}
+				for _, bid := range blocksIDs {
+					if err := c.taskStore.RemoveBlocker(bid, id); err != nil {
+						return fmt.Errorf("remove blocker: %w", err)
+					}
+				}
+			} else if cmd.Flags().Changed("blocks") {
+				// Replace: clear existing blocks, set new ones
+				blocksIDs, err := c.taskStore.ListBlocksIDs(id)
+				if err != nil {
+					return fmt.Errorf("list blocks: %w", err)
+				}
+				for _, bid := range blocksIDs {
+					if err := c.taskStore.RemoveBlocker(bid, id); err != nil {
+						return fmt.Errorf("remove blocker: %w", err)
+					}
+				}
+				newBlocks, err := parseBlocksFlag(blocks)
+				if err != nil {
+					return err
+				}
+				for _, bid := range newBlocks {
+					if err := c.taskStore.SetBlocker(bid, id); err != nil {
+						return fmt.Errorf("set blocker: %w", err)
+					}
 				}
 			}
 
@@ -282,12 +389,15 @@ func (c *CLI) editCmd() *cobra.Command {
 	cmd.Flags().StringVar(&tags, "tags", "", "New comma-separated tags (replaces all existing tags)")
 	cmd.Flags().StringVar(&recur, "recur", "", "Recurrence: none, daily, weekly, monthly, yearly")
 	cmd.Flags().BoolVar(&clearDue, "clear-due", false, "Remove the due date")
+	cmd.Flags().StringSliceVar(&meta, "meta", nil, "Metadata key=value (repeatable, merges with existing)")
+	cmd.Flags().StringVar(&blocks, "blocks", "", "Comma-separated task IDs this task blocks (replaces existing)")
+	cmd.Flags().BoolVar(&clearBlocks, "clear-blocks", false, "Remove all tasks this task blocks")
 
 	return cmd
 }
 
 func (c *CLI) deleteCmd() *cobra.Command {
-	var force bool
+	var force, cascade bool
 
 	cmd := &cobra.Command{
 		Use:     "delete <task-id>",
@@ -305,6 +415,19 @@ func (c *CLI) deleteCmd() *cobra.Command {
 				return err
 			}
 
+			// Guard: refuse to delete if this task blocks others (unless --cascade)
+			blocksIDs, err := c.taskStore.ListBlocksIDs(id)
+			if err != nil {
+				return fmt.Errorf("check dependencies: %w", err)
+			}
+			if len(blocksIDs) > 0 && !cascade {
+				idStrs := make([]string, len(blocksIDs))
+				for i, bid := range blocksIDs {
+					idStrs[i] = fmt.Sprintf("#%d", bid)
+				}
+				return fmt.Errorf("task #%d blocks %s. Use --cascade to delete and unblock them", id, strings.Join(idStrs, ", "))
+			}
+
 			ok, err := Confirm(fmt.Sprintf("Delete task #%d %q?", id, t.Title), force)
 			if err != nil {
 				return err
@@ -318,12 +441,21 @@ func (c *CLI) deleteCmd() *cobra.Command {
 				return fmt.Errorf("delete task: %w", err)
 			}
 
-			c.printer(os.Stdout).Success("Deleted task #%d: %s", id, t.Title)
+			if len(blocksIDs) > 0 {
+				idStrs := make([]string, len(blocksIDs))
+				for i, bid := range blocksIDs {
+					idStrs[i] = fmt.Sprintf("#%d", bid)
+				}
+				c.printer(os.Stdout).Success("Deleted task #%d: %s (unblocked %s)", id, t.Title, strings.Join(idStrs, ", "))
+			} else {
+				c.printer(os.Stdout).Success("Deleted task #%d: %s", id, t.Title)
+			}
 			return nil
 		},
 	}
 
 	cmd.Flags().BoolVarP(&force, "force", "y", false, "Skip confirmation prompt")
+	cmd.Flags().BoolVar(&cascade, "cascade", false, "Delete even if this task blocks others (unblocks them)")
 
 	return cmd
 }
@@ -372,6 +504,7 @@ func (c *CLI) statusCmd() *cobra.Command {
 func (c *CLI) listCmd() *cobra.Command {
 	var status, priority, sortBy, dueBefore, dueAfter, search string
 	var tags []string
+	var metaFilter []string
 	var overdue bool
 	var limit int
 
@@ -386,13 +519,14 @@ func (c *CLI) listCmd() *cobra.Command {
 			}
 
 			filtered, err := applyTaskFilters(tasks, taskFilterOpts{
-				status:    status,
-				priority:  priority,
-				tags:      tags,
-				dueBefore: dueBefore,
-				dueAfter:  dueAfter,
-				overdue:   overdue,
-				search:    search,
+				status:     status,
+				priority:   priority,
+				tags:       tags,
+				metaFilter: metaFilter,
+				dueBefore:  dueBefore,
+				dueAfter:   dueAfter,
+				overdue:    overdue,
+				search:     search,
 			})
 			if err != nil {
 				return err
@@ -416,6 +550,7 @@ func (c *CLI) listCmd() *cobra.Command {
 	cmd.Flags().StringVar(&status, "status", "all", "Filter: pending, active, done, all")
 	cmd.Flags().StringVar(&priority, "priority", "", "Filter by priority: low, medium, high, urgent")
 	cmd.Flags().StringSliceVar(&tags, "tag", nil, "Filter by tag (repeatable: --tag work --tag urgent)")
+	cmd.Flags().StringSliceVar(&metaFilter, "meta", nil, "Filter by metadata key=value (repeatable, AND logic)")
 	cmd.Flags().StringVar(&sortBy, "sort", "created", "Sort order: created, due, priority")
 	cmd.Flags().StringVar(&dueBefore, "due-before", "", "Show tasks due on or before YYYY-MM-DD")
 	cmd.Flags().StringVar(&dueAfter, "due-after", "", "Show tasks due on or after YYYY-MM-DD")
@@ -428,13 +563,14 @@ func (c *CLI) listCmd() *cobra.Command {
 
 // taskFilterOpts holds all list filter parameters.
 type taskFilterOpts struct {
-	status    string
-	priority  string
-	tags      []string
-	dueBefore string
-	dueAfter  string
-	overdue   bool
-	search    string
+	status     string
+	priority   string
+	tags       []string
+	metaFilter []string
+	dueBefore  string
+	dueAfter   string
+	overdue    bool
+	search     string
 }
 
 func applyTaskFilters(tasks []task.Task, opts taskFilterOpts) ([]task.Task, error) {
@@ -456,6 +592,16 @@ func applyTaskFilters(tasks []task.Task, opts taskFilterOpts) ([]task.Task, erro
 		})
 	}
 
+	if len(opts.metaFilter) > 0 {
+		metaKV, err := parseMetaFlags(opts.metaFilter)
+		if err != nil {
+			return nil, err
+		}
+		tasks = filterSlice(tasks, func(t task.Task) bool {
+			return taskMatchesMeta(t, metaKV)
+		})
+	}
+
 	if opts.search != "" {
 		lower := strings.ToLower(opts.search)
 		tasks = filterSlice(tasks, func(t task.Task) bool {
@@ -472,7 +618,7 @@ func applyTaskFilters(tasks []task.Task, opts taskFilterOpts) ([]task.Task, erro
 	}
 
 	if opts.dueBefore != "" {
-		if cutoff, err := time.ParseInLocation(time.DateOnly, opts.dueBefore, time.Local); err == nil {
+		if cutoff, err := time.ParseInLocation(time.DateOnly, opts.dueBefore, time.UTC); err == nil {
 			tasks = filterSlice(tasks, func(t task.Task) bool {
 				return t.DueDate != nil && !t.DueDate.After(cutoff)
 			})
@@ -480,7 +626,7 @@ func applyTaskFilters(tasks []task.Task, opts taskFilterOpts) ([]task.Task, erro
 	}
 
 	if opts.dueAfter != "" {
-		if cutoff, err := time.ParseInLocation(time.DateOnly, opts.dueAfter, time.Local); err == nil {
+		if cutoff, err := time.ParseInLocation(time.DateOnly, opts.dueAfter, time.UTC); err == nil {
 			tasks = filterSlice(tasks, func(t task.Task) bool {
 				return t.DueDate != nil && !t.DueDate.Before(cutoff)
 			})
@@ -513,6 +659,19 @@ func taskHasAnyTag(t task.Task, filterTags []string) bool {
 		}
 	}
 	return false
+}
+
+// taskMatchesMeta reports whether the task matches all given metadata key=value pairs (AND logic).
+func taskMatchesMeta(t task.Task, filter map[string]string) bool {
+	if t.Metadata == nil {
+		return false
+	}
+	for k, v := range filter {
+		if t.Metadata[k] != v {
+			return false
+		}
+	}
+	return true
 }
 
 // sortTasks sorts tasks in-place by the given sort key.
@@ -574,6 +733,20 @@ func printTasksTable(p *Printer, tasks []task.Task) error {
 		if len(t.Tags) > 0 {
 			tags = strings.Join(t.Tags, ", ")
 		}
+		completedSubs := 0
+		for _, s := range t.Subtasks {
+			if s.Completed {
+				completedSubs++
+			}
+		}
+		subs := "-"
+		if len(t.Subtasks) > 0 {
+			subs = fmt.Sprintf("%d/%d", completedSubs, len(t.Subtasks))
+		}
+		notes := "-"
+		if len(t.Notes) > 0 {
+			notes = fmt.Sprintf("%d", len(t.Notes))
+		}
 		rows = append(rows, []string{
 			fmt.Sprintf("%d", t.ID),
 			formatStatus(p, t.Status),
@@ -581,9 +754,11 @@ func printTasksTable(p *Printer, tasks []task.Task) error {
 			t.Title,
 			due,
 			tags,
+			subs,
+			notes,
 		})
 	}
-	p.Table([]string{"ID", "STATUS", "PRIORITY", "TITLE", "DUE", "TAGS"}, rows)
+	p.Table([]string{"ID", "STATUS", "PRIORITY", "TITLE", "DUE", "TAGS", "SUBS", "NOTES"}, rows)
 	return nil
 }
 
@@ -630,13 +805,31 @@ func printTaskDetail(p *Printer, t *task.Task) error {
 	}
 	subtaskStr := fmt.Sprintf("%d/%d", completedSubs, len(t.Subtasks))
 
-	var blockerStrs []string
+	var blockedByStrs []string
 	for _, bid := range t.BlockedByIDs {
-		blockerStrs = append(blockerStrs, fmt.Sprintf("#%d", bid))
+		blockedByStrs = append(blockedByStrs, fmt.Sprintf("#%d", bid))
 	}
-	blockers := "-"
-	if len(blockerStrs) > 0 {
-		blockers = strings.Join(blockerStrs, ", ")
+	blockedBy := "-"
+	if len(blockedByStrs) > 0 {
+		blockedBy = strings.Join(blockedByStrs, ", ")
+	}
+
+	var blocksStrs []string
+	for _, bid := range t.BlocksIDs {
+		blocksStrs = append(blocksStrs, fmt.Sprintf("#%d", bid))
+	}
+	blocks := "-"
+	if len(blocksStrs) > 0 {
+		blocks = strings.Join(blocksStrs, ", ")
+	}
+
+	meta := "-"
+	if len(t.Metadata) > 0 {
+		var pairs []string
+		for k, v := range t.Metadata {
+			pairs = append(pairs, k+"="+v)
+		}
+		meta = strings.Join(pairs, ", ")
 	}
 
 	label := func(s string) string { return p.Bold(s) }
@@ -652,9 +845,12 @@ func printTaskDetail(p *Printer, t *task.Task) error {
 			{label("Priority"), priority},
 			{label("Due Date"), due},
 			{label("Tags"), tags},
+			{label("Metadata"), meta},
 			{label("Recurrence"), t.RecurFreq.String()},
 			{label("Subtasks"), subtaskStr},
-			{label("Blockers"), blockers},
+			{label("Blocked By"), blockedBy},
+			{label("Blocks"), blocks},
+			{label("Notes"), fmt.Sprintf("%d", len(t.Notes))},
 			{label("Time Logged"), task.FormatDuration(task.TotalDuration(t.TimeLogs))},
 			{label("Created"), t.CreatedAt.Format("2006-01-02 15:04")},
 			{label("Updated"), t.UpdatedAt.Format("2006-01-02 15:04")},
@@ -671,7 +867,7 @@ func printTaskDetail(p *Printer, t *task.Task) error {
 			if s.Completed {
 				check = p.Colored("✓", ui.Green)
 			}
-			fmt.Fprintf(w, "  %s %s\n", check, s.Title)
+			fmt.Fprintf(w, "  %s [%d] %s\n", check, s.ID, s.Title)
 		}
 	}
 	if len(t.TimeLogs) > 0 {
@@ -681,10 +877,21 @@ func printTaskDetail(p *Printer, t *task.Task) error {
 			if tl.Note != "" {
 				note = " — " + tl.Note
 			}
-			fmt.Fprintf(w, "  %s  %s%s\n",
+			fmt.Fprintf(w, "  %s  [%d] %s%s\n",
 				p.Dim(tl.LoggedAt.Format("2006-01-02 15:04")),
+				tl.ID,
 				task.FormatDuration(tl.Duration),
 				note,
+			)
+		}
+	}
+	if len(t.Notes) > 0 {
+		fmt.Fprintf(w, "\n%s\n", p.Bold("Notes:"))
+		for _, n := range t.Notes {
+			fmt.Fprintf(w, "  %s  [%d] %s\n",
+				p.Dim(n.CreatedAt.Format("2006-01-02 15:04")),
+				n.ID,
+				n.Body,
 			)
 		}
 	}
@@ -707,23 +914,62 @@ type jsonTimeLog struct {
 	LoggedAt string `json:"logged_at"`
 }
 
-type jsonTask struct {
-	ID          int64         `json:"id"`
-	Title       string        `json:"title"`
-	Description string        `json:"description,omitempty"`
-	Status      string        `json:"status"`
-	Priority    string        `json:"priority"`
-	DueDate     string        `json:"due_date,omitempty"`
-	Tags        []string      `json:"tags"`
-	Recurrence  string        `json:"recurrence,omitempty"`
-	Subtasks    []jsonSubtask `json:"subtasks"`
-	TimeLogs    []jsonTimeLog `json:"time_logs"`
-	BlockedBy   []int64       `json:"blocked_by"`
-	CreatedAt   string        `json:"created_at"`
-	UpdatedAt   string        `json:"updated_at"`
+type jsonTaskNote struct {
+	ID        int64  `json:"id"`
+	Body      string `json:"body"`
+	CreatedAt string `json:"created_at"`
 }
 
-func taskToJSON(t *task.Task) jsonTask {
+type jsonTaskRef struct {
+	ID     int64  `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status"`
+}
+
+type jsonTask struct {
+	ID          int64             `json:"id"`
+	Title       string            `json:"title"`
+	Description string            `json:"description,omitempty"`
+	Status      string            `json:"status"`
+	Priority    string            `json:"priority"`
+	DueDate     string            `json:"due_date,omitempty"`
+	Tags        []string          `json:"tags"`
+	Metadata    map[string]string `json:"metadata,omitempty"`
+	Recurrence  string            `json:"recurrence,omitempty"`
+	Subtasks    []jsonSubtask     `json:"subtasks"`
+	TimeLogs    []jsonTimeLog     `json:"time_logs"`
+	NoteCount   int              `json:"note_count"`
+	Notes       []jsonTaskNote   `json:"notes"`
+	BlockedBy   []jsonTaskRef     `json:"blocked_by"`
+	Blocks      []jsonTaskRef     `json:"blocks"`
+	CreatedAt   string            `json:"created_at"`
+	UpdatedAt   string            `json:"updated_at"`
+}
+
+// taskIndex maps task IDs to their summary info for enriching dependency refs.
+type taskIndex map[int64]jsonTaskRef
+
+func buildTaskIndex(tasks []task.Task) taskIndex {
+	idx := make(taskIndex, len(tasks))
+	for _, t := range tasks {
+		idx[t.ID] = jsonTaskRef{ID: t.ID, Title: t.Title, Status: t.Status.String()}
+	}
+	return idx
+}
+
+func resolveRefs(ids []int64, idx taskIndex) []jsonTaskRef {
+	refs := make([]jsonTaskRef, 0, len(ids))
+	for _, id := range ids {
+		if ref, ok := idx[id]; ok {
+			refs = append(refs, ref)
+		} else {
+			refs = append(refs, jsonTaskRef{ID: id, Title: "(unknown)", Status: "Unknown"})
+		}
+	}
+	return refs
+}
+
+func taskToJSON(t *task.Task, idx taskIndex) jsonTask {
 	jt := jsonTask{
 		ID:          t.ID,
 		Title:       t.Title,
@@ -737,6 +983,7 @@ func taskToJSON(t *task.Task) jsonTask {
 	if jt.Tags == nil {
 		jt.Tags = []string{}
 	}
+	jt.Metadata = t.Metadata
 	if t.DueDate != nil {
 		jt.DueDate = t.DueDate.Format(time.DateOnly)
 	}
@@ -761,26 +1008,43 @@ func taskToJSON(t *task.Task) jsonTask {
 			LoggedAt: tl.LoggedAt.Format(time.RFC3339),
 		})
 	}
-	if t.BlockedByIDs != nil {
-		jt.BlockedBy = t.BlockedByIDs
-	} else {
-		jt.BlockedBy = []int64{}
+	jt.NoteCount = len(t.Notes)
+	jt.Notes = make([]jsonTaskNote, 0, len(t.Notes))
+	for _, n := range t.Notes {
+		jt.Notes = append(jt.Notes, jsonTaskNote{
+			ID:        n.ID,
+			Body:      n.Body,
+			CreatedAt: n.CreatedAt.Format(time.RFC3339),
+		})
 	}
+	jt.BlockedBy = resolveRefs(t.BlockedByIDs, idx)
+	jt.Blocks = resolveRefs(t.BlocksIDs, idx)
 	return jt
 }
 
 func printTasksJSON(w io.Writer, tasks []task.Task) error {
+	idx := buildTaskIndex(tasks)
 	out := make([]jsonTask, 0, len(tasks))
 	for i := range tasks {
-		out = append(out, taskToJSON(&tasks[i]))
+		out = append(out, taskToJSON(&tasks[i], idx))
 	}
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
 	return enc.Encode(out)
 }
 
-func printTaskJSON(w io.Writer, t *task.Task) error {
+func (c *CLI) printTaskJSON(w io.Writer, t *task.Task) error {
+	// For single-task view, build index from all tasks for ref resolution.
+	allTasks, err := c.taskStore.List()
+	if err != nil {
+		// Fallback: just use the task itself
+		idx := taskIndex{t.ID: {ID: t.ID, Title: t.Title, Status: t.Status.String()}}
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(taskToJSON(t, idx))
+	}
+	idx := buildTaskIndex(allTasks)
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(taskToJSON(t))
+	return enc.Encode(taskToJSON(t, idx))
 }

--- a/internal/journal/journal.go
+++ b/internal/journal/journal.go
@@ -17,8 +17,8 @@ type Note struct {
 
 // DateTitle returns the human-readable date string used as the note title.
 func (n Note) DateTitle() string {
-	now := time.Now()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.Local)
+	now := time.Now().UTC()
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
 	yesterday := today.AddDate(0, 0, -1)
 	weekAgo := today.AddDate(0, 0, -6)
 

--- a/internal/journal/store.go
+++ b/internal/journal/store.go
@@ -70,7 +70,7 @@ func (s *Store) ListNotes(includeHidden bool) ([]Note, error) {
 			return nil, err
 		}
 		n.Hidden = hidden != 0
-		d, err := time.ParseInLocation(time.DateOnly, dateStr, time.Local)
+		d, err := time.ParseInLocation(time.DateOnly, dateStr, time.UTC)
 		if err != nil {
 			return nil, fmt.Errorf("parse note date %q: %w", dateStr, err)
 		}
@@ -107,7 +107,7 @@ func (s *Store) ListNotes(includeHidden bool) ([]Note, error) {
 // GetOrCreate returns the note for dateStr (YYYY-MM-DD format), creating it
 // if it does not exist.
 func (s *Store) GetOrCreate(dateStr string) (*Note, error) {
-	now := time.Now()
+	now := time.Now().UTC()
 	nowStr := now.Format(time.RFC3339)
 
 	_, err := s.db.Exec(
@@ -128,7 +128,7 @@ func (s *Store) GetOrCreate(dateStr string) (*Note, error) {
 		return nil, fmt.Errorf("get note for %s: %w", dateStr, err)
 	}
 	n.Hidden = hidden != 0
-	d, err := time.ParseInLocation(time.DateOnly, dStr, time.Local)
+	d, err := time.ParseInLocation(time.DateOnly, dStr, time.UTC)
 	if err != nil {
 		return nil, fmt.Errorf("parse note date %q: %w", dStr, err)
 	}
@@ -153,7 +153,7 @@ func (s *Store) GetOrCreate(dateStr string) (*Note, error) {
 
 // GetOrCreateToday returns today's note, creating it if it does not exist.
 func (s *Store) GetOrCreateToday() (*Note, error) {
-	return s.GetOrCreate(time.Now().Format(time.DateOnly))
+	return s.GetOrCreate(time.Now().UTC().Format(time.DateOnly))
 }
 
 // AddEntry appends a new entry to the given note.
@@ -164,7 +164,7 @@ func (s *Store) AddEntry(noteID int64, body string) error {
 	}
 	defer tx.Rollback()
 
-	now := time.Now().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339)
 	if _, err := tx.Exec(
 		`INSERT INTO journal_entries (note_id, body, created_at) VALUES (?,?,?)`,
 		noteID, body, now,
@@ -185,7 +185,7 @@ func (s *Store) UpdateEntry(entryID int64, body string) error {
 	}
 	defer tx.Rollback()
 
-	now := time.Now().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339)
 	res, err := tx.Exec(`UPDATE journal_entries SET body = ? WHERE id = ?`, body, entryID)
 	if err != nil {
 		return fmt.Errorf("update entry: %w", err)
@@ -217,7 +217,7 @@ func (s *Store) DeleteEntry(entryID int64) error {
 	if _, err := tx.Exec(`DELETE FROM journal_entries WHERE id = ?`, entryID); err != nil {
 		return fmt.Errorf("delete entry: %w", err)
 	}
-	now := time.Now().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339)
 	if _, err := tx.Exec(`UPDATE journal_notes SET updated_at = ? WHERE id = ?`, now, noteID); err != nil {
 		return fmt.Errorf("update note timestamp: %w", err)
 	}
@@ -295,7 +295,7 @@ func (s *Store) RestoreEntry(noteID int64, body string, createdAt time.Time) err
 	); err != nil {
 		return fmt.Errorf("restore entry: %w", err)
 	}
-	now := time.Now().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339)
 	if _, err := tx.Exec(`UPDATE journal_notes SET updated_at = ? WHERE id = ?`, now, noteID); err != nil {
 		return fmt.Errorf("update note timestamp: %w", err)
 	}

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"strings"
 	"time"
@@ -59,6 +60,13 @@ func migrate(db *sql.DB) error {
 			blocked_by INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
 			PRIMARY KEY (task_id, blocked_by)
 		)`,
+		`CREATE TABLE IF NOT EXISTS task_notes (
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			task_id    INTEGER NOT NULL REFERENCES tasks(id) ON DELETE CASCADE,
+			body       TEXT NOT NULL,
+			created_at TEXT NOT NULL
+		)`,
+		`CREATE INDEX IF NOT EXISTS idx_task_notes_task ON task_notes(task_id)`,
 	}
 	for _, stmt := range stmts {
 		if _, err := db.Exec(stmt); err != nil {
@@ -72,6 +80,9 @@ func migrate(db *sql.DB) error {
 	}
 	if err := addColumnIfNotExists(db, "tasks", "recur_interval", "INTEGER NOT NULL DEFAULT 0"); err != nil {
 		return fmt.Errorf("migrate recur_interval: %w", err)
+	}
+	if err := addColumnIfNotExists(db, "tasks", "metadata", "TEXT NOT NULL DEFAULT '{}'"); err != nil {
+		return fmt.Errorf("migrate metadata: %w", err)
 	}
 	return nil
 }
@@ -105,7 +116,7 @@ func addColumnIfNotExists(db *sql.DB, table, column, colDef string) error {
 }
 
 func (s *Store) List() ([]Task, error) {
-	rows, err := s.db.Query(`SELECT id, title, description, status, priority, due_date, created_at, updated_at, recur_freq, recur_interval FROM tasks ORDER BY created_at DESC`)
+	rows, err := s.db.Query(`SELECT id, title, description, status, priority, due_date, created_at, updated_at, recur_freq, recur_interval, metadata FROM tasks ORDER BY created_at DESC`)
 	if err != nil {
 		return nil, err
 	}
@@ -115,11 +126,13 @@ func (s *Store) List() ([]Task, error) {
 	for rows.Next() {
 		var t Task
 		var dueDate, createdAt, updatedAt sql.NullString
-		if err := rows.Scan(&t.ID, &t.Title, &t.Description, &t.Status, &t.Priority, &dueDate, &createdAt, &updatedAt, &t.RecurFreq, &t.RecurInterval); err != nil {
+		var metadataStr string
+		if err := rows.Scan(&t.ID, &t.Title, &t.Description, &t.Status, &t.Priority, &dueDate, &createdAt, &updatedAt, &t.RecurFreq, &t.RecurInterval, &metadataStr); err != nil {
 			return nil, err
 		}
+		t.Metadata = parseMetadata(metadataStr)
 		if dueDate.Valid {
-			d, err := time.ParseInLocation(time.DateOnly, dueDate.String, time.Local)
+			d, err := time.ParseInLocation(time.DateOnly, dueDate.String, time.UTC)
 			if err != nil {
 				return nil, fmt.Errorf("parse task due_date %q: %w", dueDate.String, err)
 			}
@@ -155,8 +168,14 @@ func (s *Store) List() ([]Task, error) {
 		if tasks[i].TimeLogs, err = s.ListTimeLogs(tasks[i].ID); err != nil {
 			return nil, fmt.Errorf("list time logs for task %d: %w", tasks[i].ID, err)
 		}
+		if tasks[i].Notes, err = s.ListNotes(tasks[i].ID); err != nil {
+			return nil, fmt.Errorf("list notes for task %d: %w", tasks[i].ID, err)
+		}
 		if tasks[i].BlockedByIDs, err = s.ListBlockerIDs(tasks[i].ID); err != nil {
 			return nil, fmt.Errorf("list blocker ids for task %d: %w", tasks[i].ID, err)
+		}
+		if tasks[i].BlocksIDs, err = s.ListBlocksIDs(tasks[i].ID); err != nil {
+			return nil, fmt.Errorf("list blocks ids for task %d: %w", tasks[i].ID, err)
 		}
 	}
 	return tasks, nil
@@ -203,7 +222,7 @@ func (s *Store) Create(t *Task) error {
 	}
 	defer tx.Rollback()
 
-	now := time.Now()
+	now := time.Now().UTC()
 	t.CreatedAt = now
 	t.UpdatedAt = now
 	var dueStr *string
@@ -212,8 +231,8 @@ func (s *Store) Create(t *Task) error {
 		dueStr = &d
 	}
 	res, err := tx.Exec(
-		`INSERT INTO tasks (title, description, status, priority, due_date, created_at, updated_at) VALUES (?,?,?,?,?,?,?)`,
-		t.Title, t.Description, t.Status, t.Priority, dueStr, now.Format(time.RFC3339), now.Format(time.RFC3339),
+		`INSERT INTO tasks (title, description, status, priority, due_date, created_at, updated_at, metadata) VALUES (?,?,?,?,?,?,?,?)`,
+		t.Title, t.Description, t.Status, t.Priority, dueStr, now.Format(time.RFC3339), now.Format(time.RFC3339), marshalMetadata(t.Metadata),
 	)
 	if err != nil {
 		return err
@@ -253,15 +272,15 @@ func (s *Store) Update(t *Task) error {
 	}
 	defer tx.Rollback()
 
-	t.UpdatedAt = time.Now()
+	t.UpdatedAt = time.Now().UTC()
 	var dueStr *string
 	if t.DueDate != nil {
 		d := t.DueDate.Format(time.DateOnly)
 		dueStr = &d
 	}
 	if _, err := tx.Exec(
-		`UPDATE tasks SET title=?, description=?, status=?, priority=?, due_date=?, updated_at=? WHERE id=?`,
-		t.Title, t.Description, t.Status, t.Priority, dueStr, t.UpdatedAt.Format(time.RFC3339), t.ID,
+		`UPDATE tasks SET title=?, description=?, status=?, priority=?, due_date=?, updated_at=?, metadata=? WHERE id=?`,
+		t.Title, t.Description, t.Status, t.Priority, dueStr, t.UpdatedAt.Format(time.RFC3339), marshalMetadata(t.Metadata), t.ID,
 	); err != nil {
 		return err
 	}
@@ -303,7 +322,7 @@ func (s *Store) DeleteSubtask(id int64) error {
 
 // AddTimeLog records a time log entry for the given task.
 func (s *Store) AddTimeLog(taskID int64, duration time.Duration, note string) error {
-	now := time.Now().Format(time.RFC3339)
+	now := time.Now().UTC().Format(time.RFC3339)
 	_, err := s.db.Exec(
 		`INSERT INTO time_logs (task_id, duration, note, logged_at) VALUES (?,?,?,?)`,
 		taskID, int64(duration), note, now,
@@ -340,8 +359,60 @@ func (s *Store) ListTimeLogs(taskID int64) ([]TimeLog, error) {
 	return logs, rows.Err()
 }
 
+// AddNote adds a timestamped note to a task.
+func (s *Store) AddNote(taskID int64, body string) error {
+	now := time.Now().UTC().Format(time.RFC3339)
+	_, err := s.db.Exec(
+		`INSERT INTO task_notes (task_id, body, created_at) VALUES (?, ?, ?)`,
+		taskID, body, now,
+	)
+	return err
+}
+
+// ListNotes returns all notes for a task, ordered by creation time ascending.
+func (s *Store) ListNotes(taskID int64) ([]TaskNote, error) {
+	rows, err := s.db.Query(
+		`SELECT id, task_id, body, created_at FROM task_notes WHERE task_id = ? ORDER BY created_at ASC`,
+		taskID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var notes []TaskNote
+	for rows.Next() {
+		var n TaskNote
+		var createdAt string
+		if err := rows.Scan(&n.ID, &n.TaskID, &n.Body, &createdAt); err != nil {
+			return nil, err
+		}
+		parsed, err := time.Parse(time.RFC3339, createdAt)
+		if err != nil {
+			return nil, fmt.Errorf("parse task_note created_at %q: %w", createdAt, err)
+		}
+		n.CreatedAt = parsed
+		notes = append(notes, n)
+	}
+	return notes, rows.Err()
+}
+
+// UpdateNote changes the body of an existing note.
+func (s *Store) UpdateNote(id int64, body string) error {
+	_, err := s.db.Exec(`UPDATE task_notes SET body = ? WHERE id = ?`, body, id)
+	return err
+}
+
+// DeleteNote removes a note by ID.
+func (s *Store) DeleteNote(id int64) error {
+	_, err := s.db.Exec(`DELETE FROM task_notes WHERE id = ?`, id)
+	return err
+}
+
 // SetBlocker adds a dependency: taskID is blocked by blockerID.
 func (s *Store) SetBlocker(taskID, blockerID int64) error {
+	if taskID == blockerID {
+		return fmt.Errorf("task cannot block itself")
+	}
 	_, err := s.db.Exec(
 		`INSERT OR IGNORE INTO task_dependencies (task_id, blocked_by) VALUES (?,?)`,
 		taskID, blockerID,
@@ -379,6 +450,55 @@ func (s *Store) ListBlockerIDs(taskID int64) ([]int64, error) {
 	return ids, rows.Err()
 }
 
+// ListBlocksIDs returns all task IDs that this task blocks (reverse of BlockedBy).
+func (s *Store) ListBlocksIDs(taskID int64) ([]int64, error) {
+	rows, err := s.db.Query(
+		`SELECT task_id FROM task_dependencies WHERE blocked_by = ?`,
+		taskID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var ids []int64
+	for rows.Next() {
+		var id int64
+		if err := rows.Scan(&id); err != nil {
+			return nil, err
+		}
+		ids = append(ids, id)
+	}
+	return ids, rows.Err()
+}
+
+// ClearBlockers removes all blockers from a task.
+func (s *Store) ClearBlockers(taskID int64) error {
+	_, err := s.db.Exec(`DELETE FROM task_dependencies WHERE task_id = ?`, taskID)
+	return err
+}
+
+// SetBlockers replaces all blockers for a task with the given IDs.
+func (s *Store) SetBlockers(taskID int64, blockerIDs []int64) error {
+	tx, err := s.db.Begin()
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.Exec(`DELETE FROM task_dependencies WHERE task_id = ?`, taskID); err != nil {
+		return err
+	}
+	for _, bid := range blockerIDs {
+		if _, err := tx.Exec(
+			`INSERT OR IGNORE INTO task_dependencies (task_id, blocked_by) VALUES (?,?)`,
+			taskID, bid,
+		); err != nil {
+			return err
+		}
+	}
+	return tx.Commit()
+}
+
 // UpdateRecurrence sets the recurrence frequency and interval for a task.
 func (s *Store) UpdateRecurrence(taskID int64, freq RecurFreq, interval int) error {
 	_, err := s.db.Exec(
@@ -402,10 +522,10 @@ func (s *Store) Restore(t *Task) error {
 		dueStr = &d
 	}
 	res, err := tx.Exec(
-		`INSERT INTO tasks (title, description, status, priority, due_date, created_at, updated_at, recur_freq, recur_interval) VALUES (?,?,?,?,?,?,?,?,?)`,
+		`INSERT INTO tasks (title, description, status, priority, due_date, created_at, updated_at, recur_freq, recur_interval, metadata) VALUES (?,?,?,?,?,?,?,?,?,?)`,
 		t.Title, t.Description, t.Status, t.Priority, dueStr,
 		t.CreatedAt.Format(time.RFC3339), t.UpdatedAt.Format(time.RFC3339),
-		int(t.RecurFreq), t.RecurInterval,
+		int(t.RecurFreq), t.RecurInterval, marshalMetadata(t.Metadata),
 	)
 	if err != nil {
 		return err
@@ -443,14 +563,16 @@ func (s *Store) RestoreSubtask(taskID int64, title string, completed bool, posit
 func (s *Store) GetByID(id int64) (*Task, error) {
 	var t Task
 	var dueDate, createdAt, updatedAt sql.NullString
+	var metadataStr string
 	err := s.db.QueryRow(
-		`SELECT id, title, description, status, priority, due_date, created_at, updated_at, recur_freq, recur_interval FROM tasks WHERE id = ?`, id,
-	).Scan(&t.ID, &t.Title, &t.Description, &t.Status, &t.Priority, &dueDate, &createdAt, &updatedAt, &t.RecurFreq, &t.RecurInterval)
+		`SELECT id, title, description, status, priority, due_date, created_at, updated_at, recur_freq, recur_interval, metadata FROM tasks WHERE id = ?`, id,
+	).Scan(&t.ID, &t.Title, &t.Description, &t.Status, &t.Priority, &dueDate, &createdAt, &updatedAt, &t.RecurFreq, &t.RecurInterval, &metadataStr)
 	if err != nil {
 		return nil, err
 	}
+	t.Metadata = parseMetadata(metadataStr)
 	if dueDate.Valid {
-		d, _ := time.ParseInLocation(time.DateOnly, dueDate.String, time.Local)
+		d, _ := time.ParseInLocation(time.DateOnly, dueDate.String, time.UTC)
 		t.DueDate = &d
 	}
 	if createdAt.Valid {
@@ -462,6 +584,32 @@ func (s *Store) GetByID(id int64) (*Task, error) {
 	t.Subtasks, _ = s.listSubtasks(t.ID)
 	t.Tags, _ = s.listTags(t.ID)
 	t.TimeLogs, _ = s.ListTimeLogs(t.ID)
+	t.Notes, _ = s.ListNotes(t.ID)
 	t.BlockedByIDs, _ = s.ListBlockerIDs(t.ID)
+	t.BlocksIDs, _ = s.ListBlocksIDs(t.ID)
 	return &t, nil
+}
+
+// marshalMetadata serializes a metadata map to JSON for storage.
+func marshalMetadata(m map[string]string) string {
+	if len(m) == 0 {
+		return "{}"
+	}
+	b, _ := json.Marshal(m)
+	return string(b)
+}
+
+// parseMetadata deserializes a JSON string into a metadata map.
+func parseMetadata(s string) map[string]string {
+	if s == "" || s == "{}" {
+		return nil
+	}
+	var m map[string]string
+	if err := json.Unmarshal([]byte(s), &m); err != nil {
+		return nil
+	}
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }

--- a/internal/task/store.go
+++ b/internal/task/store.go
@@ -559,6 +559,15 @@ func (s *Store) RestoreSubtask(taskID int64, title string, completed bool, posit
 	return err
 }
 
+// RestoreNote re-inserts a previously deleted note with its original timestamp.
+func (s *Store) RestoreNote(taskID int64, body string, createdAt time.Time) error {
+	_, err := s.db.Exec(
+		`INSERT INTO task_notes (task_id, body, created_at) VALUES (?,?,?)`,
+		taskID, body, createdAt.Format(time.RFC3339),
+	)
+	return err
+}
+
 // GetByID retrieves a single task by ID.
 func (s *Store) GetByID(id int64) (*Task, error) {
 	var t Task

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -87,6 +87,13 @@ type Subtask struct {
 	Position  int
 }
 
+type TaskNote struct {
+	ID        int64
+	TaskID    int64
+	Body      string
+	CreatedAt time.Time
+}
+
 type Task struct {
 	ID            int64
 	Title         string
@@ -98,10 +105,13 @@ type Task struct {
 	UpdatedAt     time.Time
 	Subtasks      []Subtask
 	Tags          []string
+	Metadata      map[string]string
 	RecurFreq     RecurFreq
 	RecurInterval int
 	TimeLogs      []TimeLog
+	Notes         []TaskNote
 	BlockedByIDs  []int64
+	BlocksIDs     []int64
 }
 
 // FilterValue implements list.Item interface for bubbles list.

--- a/internal/ui/form.go
+++ b/internal/ui/form.go
@@ -27,6 +27,13 @@ type TaskFormData struct {
 	DueDate     string
 	Tags        string
 	RecurFreq   string
+	Metadata    string // "key=value, key2=value2"
+	Blocks      string // "1, 2, 3" (task IDs)
+}
+
+// NoteFormData holds the note form field value.
+type NoteFormData struct {
+	Body string
 }
 
 // ExportFormData holds the export form field values.
@@ -91,6 +98,17 @@ func NewTaskForm(data *TaskFormData) *huh.Form {
 					huh.NewOption("Yearly", "yearly").Selected(data.RecurFreq == "yearly"),
 				).
 				Value(&data.RecurFreq),
+
+			huh.NewInput().
+				Title("Metadata").
+				Placeholder("key=value, key2=value2").
+				Value(&data.Metadata),
+
+			huh.NewInput().
+				Title("Blocks (task IDs)").
+				Placeholder("comma separated IDs").
+				Value(&data.Blocks).
+				Validate(validateOptionalBlocks),
 		),
 	).WithTheme(FormTheme()).WithShowHelp(true)
 }
@@ -140,6 +158,31 @@ func EditTaskForm(data *TaskFormData) *huh.Form {
 					huh.NewOption("Yearly", "yearly").Selected(data.RecurFreq == "yearly"),
 				).
 				Value(&data.RecurFreq),
+
+			huh.NewInput().
+				Title("Metadata").
+				Placeholder("key=value, key2=value2").
+				Value(&data.Metadata),
+
+			huh.NewInput().
+				Title("Blocks (task IDs)").
+				Placeholder("comma separated IDs").
+				Value(&data.Blocks).
+				Validate(validateOptionalBlocks),
+		),
+	).WithTheme(FormTheme()).WithShowHelp(true)
+}
+
+// NoteForm creates a form for adding or editing a task note.
+func NoteForm(data *NoteFormData) *huh.Form {
+	return huh.NewForm(
+		huh.NewGroup(
+			huh.NewText().
+				Title("Note").
+				Value(&data.Body).
+				Lines(3).
+				CharLimit(2000).
+				Validate(validateNotBlank),
 		),
 	).WithTheme(FormTheme()).WithShowHelp(true)
 }
@@ -231,6 +274,23 @@ func validateDuration(s string) error {
 	_, err := task.ParseDuration(s)
 	if err != nil {
 		return fmt.Errorf("use format like 1h30m, 45m, 2h")
+	}
+	return nil
+}
+
+func validateOptionalBlocks(s string) error {
+	if s == "" {
+		return nil
+	}
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		v, err := strconv.Atoi(part)
+		if err != nil || v <= 0 {
+			return fmt.Errorf("use comma-separated positive IDs (e.g. 1, 2, 3)")
+		}
 	}
 	return nil
 }

--- a/internal/ui/views.go
+++ b/internal/ui/views.go
@@ -66,7 +66,8 @@ func RenderTabs(activeTab int, allCount, activeCount, doneCount, journalCount in
 // RenderDetail renders the task detail panel content.
 // subtaskIdx indicates which subtask has the cursor (-1 for none).
 // detailFocused controls whether the subtask cursor is shown.
-func RenderDetail(t *task.Task, width int, subtaskIdx int, detailFocused bool) string {
+// noteIdx and notesFocused control the notes cursor when in note navigation mode.
+func RenderDetail(t *task.Task, width int, subtaskIdx int, detailFocused bool, noteIdx int, notesFocused bool) string {
 	if t == nil {
 		return lipgloss.NewStyle().
 			Foreground(Gray).
@@ -148,6 +149,15 @@ func RenderDetail(t *task.Task, width int, subtaskIdx int, detailFocused bool) s
 		sections = append(sections, RenderMarkdown(t.Description, width-2))
 	}
 
+	// Metadata
+	if len(t.Metadata) > 0 {
+		var pairs []string
+		for k, v := range t.Metadata {
+			pairs = append(pairs, k+"="+v)
+		}
+		sections = append(sections, labelStyle().Render("Metadata")+valueStyle().Render(strings.Join(pairs, ", ")))
+	}
+
 	// Subtasks
 	if len(t.Subtasks) > 0 {
 		sections = append(sections, "")
@@ -160,9 +170,10 @@ func RenderDetail(t *task.Task, width int, subtaskIdx int, detailFocused bool) s
 		sections = append(sections, labelStyle().Render("Subtasks")+valueStyle().Render(fmt.Sprintf("%d/%d", doneCount, len(t.Subtasks))))
 		sections = append(sections, renderProgressBar(doneCount, len(t.Subtasks), width-4))
 		sections = append(sections, "")
+		showSubCursor := detailFocused && !notesFocused
 		for i, st := range t.Subtasks {
 			prefix := "  "
-			if detailFocused && i == subtaskIdx {
+			if showSubCursor && i == subtaskIdx {
 				prefix = "▸ "
 			}
 			if st.Completed {
@@ -170,6 +181,21 @@ func RenderDetail(t *task.Task, width int, subtaskIdx int, detailFocused bool) s
 			} else {
 				sections = append(sections, lipgloss.NewStyle().Foreground(White).Render(prefix+"[ ] "+st.Title))
 			}
+		}
+	}
+
+	// Notes
+	if len(t.Notes) > 0 {
+		sections = append(sections, "")
+		sections = append(sections, labelStyle().Render("Notes")+valueStyle().Render(fmt.Sprintf("%d", len(t.Notes))))
+		sections = append(sections, "")
+		for i, n := range t.Notes {
+			prefix := "  "
+			if detailFocused && notesFocused && i == noteIdx {
+				prefix = lipgloss.NewStyle().Foreground(Cyan).Render("▸ ")
+			}
+			ts := lipgloss.NewStyle().Foreground(Gray).Render(n.CreatedAt.Format("Jan 02 15:04"))
+			sections = append(sections, prefix+ts+" "+n.Body)
 		}
 	}
 
@@ -244,7 +270,7 @@ func renderProgressBar(done, total, width int) string {
 // activeTab: 0-2 for task tabs, 3 for journal tab.
 // timerStr: optional focus timer string (e.g. "🍅 12:34") shown when non-empty.
 // undoAvailable: whether an undo action is available.
-func RenderStatusBar(total, done, active int, width int, statusMsg string, focusedPanel int, activeTab int, timerStr string, undoAvailable bool) string {
+func RenderStatusBar(total, done, active int, width int, statusMsg string, focusedPanel int, activeTab int, timerStr string, undoAvailable bool, notesFocused bool) string {
 	keyStyle := lipgloss.NewStyle().Foreground(Cyan)
 	dimStyle := lipgloss.NewStyle().Foreground(Gray)
 	panelStyle := lipgloss.NewStyle().Foreground(Cyan).Bold(true)
@@ -329,10 +355,15 @@ func RenderStatusBar(total, done, active int, width int, statusMsg string, focus
 
 	// Context-sensitive key hints.
 	var bindings []struct{ key, desc string }
-	if focusedPanel == 1 {
+	if focusedPanel == 1 && notesFocused {
+		bindings = []struct{ key, desc string }{
+			{"a", "add"}, {"e", "edit"}, {"d", "del"},
+			{"n", "subtasks"}, {"j/k", "nav"}, {"?", "help"},
+		}
+	} else if focusedPanel == 1 {
 		bindings = []struct{ key, desc string }{
 			{"a", "add"}, {"e", "edit"}, {"d", "del"}, {"s", "toggle"},
-			{"l", "log"}, {"b", "blockers"}, {"j/k", "nav"}, {"?", "help"},
+			{"l", "log"}, {"b", "blockers"}, {"n", "notes"}, {"j/k", "nav"}, {"?", "help"},
 		}
 	} else {
 		bindings = []struct{ key, desc string }{


### PR DESCRIPTION
## Summary

I use rondo as part of an automation pipeline where tasks are created from external sources. These changes add the missing pieces: metadata for origin context (--meta source=email), notes for status updates without cluttering descriptions, batch mode for piping commands from scripts, and a delete guard after I accidentally removed a task that others depended on. Everything is wired into the TUI so nothing is CLI-only.

- Task metadata: structured key-value pairs stored as JSON column, with `--meta` flag on add/edit/list and AND-logic filtering
- Task notes: timestamped comments via `rondo note` subcommand (add, list, edit, delete) and full TUI support with `n` key navigation
- Batch mode: `rondo batch` reads newline-delimited JSON commands from stdin
- Delete guard: refuses to delete tasks that block others unless `--cascade` is passed
- Blocker improvements: `--blocks`/`--clear-blocks` flags, reverse dependency tracking, self-block prevention, enriched JSON refs with `{id, title, status}`
- TUI wiring: metadata and blocks fields in task forms, note CRUD with undo, bidirectional blocker overlay, note count in task list delegate
- UTC normalization across all store and CLI date operations

## Test plan

- [ ] `go build ./cmd/todo && go vet ./... && go test ./...` passes
- [ ] `rondo add "test" --meta source=api --blocks 1` creates task with metadata and blocker
- [ ] `rondo list --meta source=api` filters correctly
- [ ] `rondo note add 1 "test note"` and `rondo note list 1` work
- [ ] `rondo delete 1 --force` fails when task blocks others; `--cascade` succeeds
- [ ] `echo '{"cmd":"add","args":["batch task"]}' | rondo batch` produces JSON result
- [ ] TUI: `n` key toggles note navigation in detail panel, add/edit/delete notes work
- [ ] TUI: edit task form shows metadata and blocks fields
- [ ] TUI: blocker overlay shows both "blocked by" and "blocks" sections